### PR TITLE
1894: Move or remove ORG id

### DIFF
--- a/src/app/modules/querybuilder-module/fragments/core-filters/index.tsx
+++ b/src/app/modules/querybuilder-module/fragments/core-filters/index.tsx
@@ -76,7 +76,7 @@ export const CoreFiltersFragment = () => {
         <ConnectedSelect
           {...fragmentConfig.organisations}
           value={store.get('organisations')}
-          options={fetchedsectorOrganisations}
+          options={fetchedsectorOrganisations.sort((a, b) => a.reporting_organisation.localeCompare(b.reporting_organisation))}
           onChange={(e) => store.set('organisations')(e)}
           // placeholder={`All (${fetchedsectorOrganisations.length})`}
           placeholder={`All organisations`}

--- a/src/app/modules/querybuilder-module/fragments/core-filters/model.ts
+++ b/src/app/modules/querybuilder-module/fragments/core-filters/model.ts
@@ -45,7 +45,7 @@ export const fragmentConfig: FragmentModel = {
     // helperTextUrl: 'http://reference.iatistandard.org/203/codelists/Sector/',
     placeholder: 'All (0)',
     getOptionLabel: (option: OrganisationModel) =>
-      `${option.reporting_organisation_identifier}: ${option.reporting_organisation}`,
+      `${option.reporting_organisation} (${option.reporting_organisation_identifier})`,
     getOptionValue: (option: OrganisationModel) =>
       option.reporting_organisation_identifier,
   },


### PR DESCRIPTION
https://app.zenhub.com/workspaces/iaticloud-5b8e865bb2cc7b6c78ece322/issues/zimmerman-team/iati.cloud/1894

Requirements listed by Siem:
In the QB the org listing in Step 1 is
NL-KVK-40530953: Amnesty International The Netherlands
ORG-ID: Nice name
Lets revert to :
Nice name (ORG-ID) in alphabetical order.

In this PR:
-Change format of Reporting Organisations option label: {Nice Name} ({ORG-ID})
-Sort Reporting Organisations in alphabetical order.