### PR TITLE
feat: remove matomo tracking and add gtagmanager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
                   source $BASH_ENV
           wait-on: "http://localhost:3000"
           yarn: true
-          start: yarn start
+          start: npm start
           browser: chrome
           requires:
             - "checkout"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,51 +68,18 @@ workflows:
           yarn: true
           build: yarn build
 
-      #       - cypress/run:
-      #           name: "local e2e tests"
-      #           executor: cypress-executor
-      #           pre-steps:
-      #             - run:
-      #                 name: Set env variables
-      #                 command: |
-      #                     echo 'export CYPRESS_BASE_URL="http://localhost:3000"' >> $BASH_ENV
-      #                   source $BASH_ENV
-      #           wait-on: "http://localhost:3000"
-      #           yarn: true
-      #           start: yarn start:ci
-      #           browser: chrome
-      #           requires:
-      #             - deploy
-      #           record: true
-      #           parallel: true
-      #           parallelism: 5
-      #           group: "all tests"
-      #
-      #       - deploy:
-      #           requires:
-      #             - "checkout"
-      #             # - "local e2e tests"
-      - deploy:
-          requires:
-            - "checkout"
-            # - "local e2e tests"
-
       - cypress/run:
-          name: "deployed e2e tests"
+          name: "local e2e tests"
           executor: cypress-executor
           pre-steps:
             - run:
                 name: Set env variables
                 command: |
-                  if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                    echo 'export CYPRESS_BASE_URL="https://iatidatastore.iatistandard.org"' >> $BASH_ENV
-                  elif [ "${CIRCLE_BRANCH}" == "develop" ]; then
-                    echo 'export CYPRESS_BASE_URL="https://store.staging.iati.cloud"' >> $BASH_ENV
-                  else
-                    echo 'export CYPRESS_BASE_URL="https://store.staging.iati.cloud"' >> $BASH_ENV
-                  fi
+                  echo 'export CYPRESS_BASE_URL="http://localhost:3000"' >> $BASH_ENV
                   source $BASH_ENV
+          wait-on: "http://localhost:3000"
           yarn: true
+          start: yarn start
           browser: chrome
           requires:
             - "checkout"
@@ -120,6 +87,34 @@ workflows:
           parallel: true
           parallelism: 5
           group: "all tests"
+
+      - deploy:
+          requires:
+            - "local e2e tests"
+
+      # - cypress/run:
+      #     name: "deployed e2e tests"
+      #     executor: cypress-executor
+      #     pre-steps:
+      #       - run:
+      #           name: Set env variables
+      #           command: |
+      #             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+      #               echo 'export CYPRESS_BASE_URL="https://iatidatastore.iatistandard.org"' >> $BASH_ENV
+      #             elif [ "${CIRCLE_BRANCH}" == "develop" ]; then
+      #               echo 'export CYPRESS_BASE_URL="https://store.staging.iati.cloud"' >> $BASH_ENV
+      #             else
+      #               echo 'export CYPRESS_BASE_URL="https://store.staging.iati.cloud"' >> $BASH_ENV
+      #             fi
+      #             source $BASH_ENV
+      #     yarn: true
+      #     browser: chrome
+      #     requires:
+      #       - "checkout"
+      #     record: true
+      #     parallel: true
+      #     parallelism: 5
+      #     group: "all tests"
 
       - release:
           requires:

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "projectId": "joyvah",
   "baseUrl": "http://localhost:3000",
   "chromeWebSecurity": false,
-  "pageLoadTimeout": 10000,
+  "pageLoadTimeout": 30000,
   "viewportWidth": 1440,
   "viewportHeight": 900,
   "video": false

--- a/cypress/integration/apiDocNavigation.spec.ts
+++ b/cypress/integration/apiDocNavigation.spec.ts
@@ -20,11 +20,13 @@ const categories: string[] = [
   // 'Transaction List',
   // 'Transaction Aggregations',
   // 'DataStore Search Engine',
+  'Apache Solr API',
+  'Activity List',
   'Budget List',
   'Budget Aggregations',
   'Codelist Meta List',
   'Country List',
-  'Dataset List',
+  'Datasets',
   'Location List',
   'Organisation List',
   'Publisher List',
@@ -33,6 +35,7 @@ const categories: string[] = [
   'Result Aggregations',
   'Sector List',
   'Transaction List',
+  'Transaction Aggregations',
 ];
 
 describe('API Documentation - navigation', function () {

--- a/public/index.html
+++ b/public/index.html
@@ -20,35 +20,14 @@
     Learn how to configure a non-root public URL by running `npm run build`.
   -->
 
-  <script type="text/javascript">
-    var _paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */ _paq.push(
-            ['setDocumentTitle', document.domain + '/' + document.title]
-    );
-    _paq.push(['setCookieDomain', '*.iatidatastore.iatistandard.org']);
-    _paq.push([
-      'setDomains',
-      [
-        '*.iatidatastore.iatistandard.org',
-        '*.iati.cloud',
-        '*.www.iati.cloud',
-      ],
-    ]);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u = 'https://zimmermanzimmerman.matomo.cloud/';
-      _paq.push(['setTrackerUrl', u + 'matomo.php']);
-      _paq.push(['setSiteId', '5']);
-      var d = document,
-              g = d.createElement('script'),
-              s = d.getElementsByTagName('script')[0];
-      g.type = 'text/javascript';
-      g.async = true;
-      g.defer = true;
-      g.src = '//cdn.matomo.cloud/zimmermanzimmerman.matomo.cloud/matomo.js';
-      s.parentNode.insertBefore(g, s);
-    })();
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-CP65J0T1G0"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-CP65J0T1G0');
   </script>
 
   <script src="https://unpkg.com/web-streams-polyfill@2.0.4/dist/ponyfill.es6.js"></script>


### PR DESCRIPTION
implements [gb-58](https://zimmermanzimmerman.atlassian.net/secure/RapidBoard.jspa?rapidView=46&modal=detail&selectedIssue=GB-58)

removal based on [addition](https://github.com/zimmerman-team/iati.cloud.frontend/commit/2f3eb4e34df6344c43591f8eba1b17c4ae1606f0) and the snippet provided in the ticket.

Note: pretty-quick was added, not removing it as it is in pre-commit hook.